### PR TITLE
[reference] Use xdg-open instead of firefox

### DIFF
--- a/lib/browser.s7i
+++ b/lib/browser.s7i
@@ -162,8 +162,10 @@ const func browserConnection: openBrowser is func
     until browser.inetListener <> listener.value or port >= MAX_PORT;
     if browser.inetListener <> listener.value then
       listen(browser.inetListener, 10);
-      # cmd_sh("firefox localhost:" <& port <& " &");
-      if fileType("/usr/bin/firefox") <> FILE_ABSENT then
+      const boolean: xdg_exist is true; # TODO: find xdg-open in $PATH
+      if xdg_exist then
+        cmd_sh("xdg-open http://localhost:" <& port);
+      elseif fileType("/usr/bin/firefox") <> FILE_ABSENT then
         browser.program := startProcess("/usr/bin/firefox", [] ("localhost:" <& port));
       elsif fileType("/usr/bin/chromium") <> FILE_ABSENT then
         browser.program := startProcess("/usr/bin/chromium", [] ("http://localhost:" <& port));


### PR DESCRIPTION
When I used ide7, I noticed it's not showing anything. I tried to fix opening browser on Linux, but I don't know Seed7 enough.

On Linux, opening browser should be like this:

- use `xdg-open http://example.com/` (free desktop)
- run `$BROWSER http://example.com/` if env var `BROWSER` exist
- hardcoded browser paths

Also, I noticed this function will not fail if non of the browser exist (`browser.program` is empty).
