### PR TITLE
Fix typo (`Respose` → `Response`)

### DIFF
--- a/lib/http_response.s7i
+++ b/lib/http_response.s7i
@@ -39,7 +39,7 @@ include "shell.s7i";
  *  where the files are found. Additionally it defines also which directory
  *  from a HTTP request should be interpreted as CGI directory.
  *)
-const type: httpResposeData is new struct
+const type: httpResponseData is new struct
     var string: htdocs is "";
     var string: cgiDir is "";
     var string: cgiName is "";
@@ -53,12 +53,12 @@ const type: httpResposeData is new struct
  *  @param cgiDir Path of the directory with the CGI programs (cgi-bin directory).
  *  @param cgiName Name of the CGI directory in HTTP requests.
  *  @param backendSys File system where the ''htdocs'' and ''cgiDir'' files are found.
- *  @return a ''httpResposeData'' value with the given parameters.
+ *  @return a ''httpResponseData'' value with the given parameters.
  *)
-const func httpResposeData: httpResposeData (in string: htdocs, in string: cgiDir,
+const func httpResponseData: httpResponseData (in string: htdocs, in string: cgiDir,
     in string: cgiName, inout fileSys: backendSys) is func
   result
-    var httpResposeData: responseData is httpResposeData.value;
+    var httpResponseData: responseData is httpResponseData.value;
   begin
     responseData.htdocs := toAbsPath(getcwd(backendSys), htdocs);
     responseData.cgiDir := toAbsPath(getcwd(backendSys), cgiDir);
@@ -158,7 +158,7 @@ const proc: sendClientError (inout file: sock, in integer: statuscode,
   end func;
 
 
-const func string: callCgi (in httpResposeData: responseData, in string: filePath,
+const func string: callCgi (in httpResponseData: responseData, in string: filePath,
     in string: queryParams, in string: postParams, in string: cookies,
     inout array string: header) is func
   result
@@ -247,7 +247,7 @@ const func string: callCgi (in httpResposeData: responseData, in string: filePat
  *  @param responseData The data source of a web server.
  *  @param request The [[httpserv#httpRequest|httpRequest]] (GET) to be processed.
  *)
-const proc: processGet (inout httpResposeData: responseData,
+const proc: processGet (inout httpResponseData: responseData,
     inout httpRequest: request) is func
   local
     var string: filePath is "";
@@ -313,7 +313,7 @@ const proc: processGet (inout httpResposeData: responseData,
  *  @param responseData The data source of a web server.
  *  @param request The [[httpserv#httpRequest|httpRequest]] (POST) to be processed.
  *)
-const proc: processPost (in httpResposeData: responseData,
+const proc: processPost (in httpResponseData: responseData,
     inout httpRequest: request) is func
   local
     var string: cookies is "";

--- a/prg/comanche.sd7
+++ b/prg/comanche.sd7
@@ -56,7 +56,7 @@ const proc: main is func
     var integer: port is 1080;
     var httpServer: server is httpServer.value;
     var httpRequest: request is httpRequest.value;
-    var httpResposeData: responseData is httpResposeData.value;
+    var httpResponseData: responseData is httpResponseData.value;
   begin
     writeln("Comanche Version 2.0 - Simple webserver for static and cgi pages");
     writeln("Copyright (C) 2009 - 2017, 2023 Thomas Mertes");
@@ -120,7 +120,7 @@ const proc: main is func
           cgiName := cgiDir[slashPos ..] & "/";
         end if;
       end if;
-      responseData := httpResposeData(htdocs, cgiDir, cgiName, osFiles);
+      responseData := httpResponseData(htdocs, cgiDir, cgiName, osFiles);
       if fileType(responseData.backendSys, responseData.htdocs) <> FILE_DIR then
         writeln(" *** Directory " <& literal(responseData.htdocs) <& " not found.");
         writeln("     You need to specify a directory which contains");


### PR DESCRIPTION
Hi @ThomasMertes! I've been lurking on the Seed7 docs recently and noticed the `httpResponseData` type was missing an "n". Let me know if there's anywhere else it needs to be updated.
Cheers!