### PR TITLE
Correctly handle /./../ sequences in toAbsPath

### DIFF
--- a/lib/osfiles.s7i
+++ b/lib/osfiles.s7i
@@ -766,6 +766,7 @@ const func string: toAbsPath (in string: basePath, in string: path) is func
     else
       absolutePath := getcwd & "/" & basePath & "/" & path;
     end if;
+    absolutePath := replace(absolutePath, "/./", "/");
     dotdotPos := pos(absolutePath, "/..");
     while dotdotPos <> 0 do
       slashPos := rpos(absolutePath, '/', pred(dotdotPos));
@@ -787,7 +788,6 @@ const func string: toAbsPath (in string: basePath, in string: path) is func
         dotdotPos := pos(absolutePath, "/..", succ(dotdotPos));
       end if;
     end while;
-    absolutePath := replace(absolutePath, "/./", "/");
     if endsWith(absolutePath, "/.") then
       if absolutePath = "/." then
         absolutePath := "/";


### PR DESCRIPTION
The toAbsPath function does not handle the sequence "/./../" in a path correctly. 

For example, if the current directory is "/home/rooftop/test", then

`toAbsPath(".", "../file.txt")` returns "/home/rooftop/test/file.txt" instead of the expected "/home/rooftop/file.txt".