### PR TITLE
Eliminate LTO-related warnings

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -231,7 +231,7 @@ strip:
 
 chkccomp.h:
 	echo "#define LIST_DIRECTORY_CONTENTS \"ls\"" > chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_STATIC_LINKING \"-static\"" >> chkccomp.h
 	echo "#define LINKER_OPT_NO_LTO \"-fno-lto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_DYN_LINK_LIBS \"-ldl\"" >> chkccomp.h

--- a/src/mk_clang.mak
+++ b/src/mk_clang.mak
@@ -231,7 +231,7 @@ strip:
 
 chkccomp.h:
 	echo "#define LIST_DIRECTORY_CONTENTS \"ls\"" > chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_DYN_LINK_LIBS \"-ldl\"" >> chkccomp.h
 	echo "#define POTENTIAL_PARTIAL_LINKING_OPTIONS \"-r\"" >> chkccomp.h
 	echo "#define USE_GMP 0" >> chkccomp.h

--- a/src/mk_clangw.mak
+++ b/src/mk_clangw.mak
@@ -221,7 +221,7 @@ strip:
 
 chkccomp.h:
 	echo #define LIST_DIRECTORY_CONTENTS "dir" > chkccomp.h
-	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto" >> chkccomp.h
+	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto=auto" >> chkccomp.h
 	echo #define USE_GMP 0 >> chkccomp.h
 	echo #define SYSTEM_CONSOLE_LIBS "$(SYSTEM_CONSOLE_LIBS)" >> chkccomp.h
 	echo #define SYSTEM_DRAW_LIBS "$(SYSTEM_DRAW_LIBS)" >> chkccomp.h

--- a/src/mk_cygw.mak
+++ b/src/mk_cygw.mak
@@ -220,7 +220,7 @@ strip:
 
 chkccomp.h:
 	echo "#define LIST_DIRECTORY_CONTENTS \"ls\"" > chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_STATIC_LINKING \"-static\"" >> chkccomp.h
 	echo "#define LINKER_OPT_NO_LTO \"-fno-lto\"" >> chkccomp.h
 	echo "#define POTENTIAL_PARTIAL_LINKING_OPTIONS \"-r\"" >> chkccomp.h

--- a/src/mk_linux.mak
+++ b/src/mk_linux.mak
@@ -231,7 +231,7 @@ strip:
 
 chkccomp.h:
 	echo "#define LIST_DIRECTORY_CONTENTS \"ls\"" > chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_STATIC_LINKING \"-static\"" >> chkccomp.h
 	echo "#define LINKER_OPT_NO_LTO \"-fno-lto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_DYN_LINK_LIBS \"-ldl\"" >> chkccomp.h

--- a/src/mk_mingc.mak
+++ b/src/mk_mingc.mak
@@ -199,7 +199,7 @@ chkccomp.h:
 	echo #define LINKER_OPT_STATIC_LINKING "-static" >> chkccomp.h
 	echo #define CC_FLAGS "-ffunction-sections -fdata-sections" >> chkccomp.h
 	echo #define CC_FLAGS64 "-Wa,-mbig-obj" >> chkccomp.h
-	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto" >> chkccomp.h
+	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto=auto" >> chkccomp.h
 	echo #define LINKER_OPT_NO_LTO "-fno-lto" >> chkccomp.h
 	echo #define USE_GMP 0 >> chkccomp.h
 	echo #define SYSTEM_CONSOLE_LIBS "$(SYSTEM_CONSOLE_LIBS)" >> chkccomp.h

--- a/src/mk_mingw.mak
+++ b/src/mk_mingw.mak
@@ -223,7 +223,7 @@ chkccomp.h:
 	echo #define LINKER_OPT_STATIC_LINKING "-static" >> chkccomp.h
 	echo #define CC_FLAGS "-ffunction-sections -fdata-sections" >> chkccomp.h
 	echo #define CC_FLAGS64 "-Wa,-mbig-obj" >> chkccomp.h
-	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto" >> chkccomp.h
+	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto=auto" >> chkccomp.h
 	echo #define LINKER_OPT_NO_LTO "-fno-lto" >> chkccomp.h
 	echo #define POTENTIAL_PARTIAL_LINKING_OPTIONS "-r" >> chkccomp.h
 	echo #define USE_GMP 0 >> chkccomp.h

--- a/src/mk_msys.mak
+++ b/src/mk_msys.mak
@@ -187,7 +187,7 @@ chkccomp.h:
 	echo "#define LINKER_OPT_STATIC_LINKING \"-static\"" >> chkccomp.h
 	echo "#define CC_FLAGS \"-ffunction-sections -fdata-sections\"" >> chkccomp.h
 	echo "#define CC_FLAGS64 \"-Wa,-mbig-obj\"" >> chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_NO_LTO \"-fno-lto\"" >> chkccomp.h
 	echo "#define POTENTIAL_PARTIAL_LINKING_OPTIONS \"-r\"" >> chkccomp.h
 	echo "#define USE_GMP 0" >> chkccomp.h

--- a/src/mk_nmake.mak
+++ b/src/mk_nmake.mak
@@ -225,7 +225,7 @@ chkccomp.h:
 	echo #define LINKER_OPT_STATIC_LINKING "-static" >> chkccomp.h
 	echo #define CC_FLAGS "-ffunction-sections -fdata-sections" >> chkccomp.h
 	echo #define CC_FLAGS64 "-Wa,-mbig-obj" >> chkccomp.h
-	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto" >> chkccomp.h
+	echo #define CC_OPT_LINK_TIME_OPTIMIZATION "-flto=auto" >> chkccomp.h
 	echo #define LINKER_OPT_NO_LTO "-fno-lto" >> chkccomp.h
 	echo #define POTENTIAL_PARTIAL_LINKING_OPTIONS "-r" >> chkccomp.h
 	echo #define USE_GMP 0 >> chkccomp.h

--- a/src/mk_osx.mak
+++ b/src/mk_osx.mak
@@ -224,7 +224,7 @@ strip:
 
 chkccomp.h:
 	echo "#define LIST_DIRECTORY_CONTENTS \"ls\"" > chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_STATIC_LINKING \"-static\"" >> chkccomp.h
 	echo "#define LINKER_OPT_NO_LTO \"-fno-lto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_DYN_LINK_LIBS \"-ldl\"" >> chkccomp.h

--- a/src/mk_osxcl.mak
+++ b/src/mk_osxcl.mak
@@ -226,7 +226,7 @@ strip:
 
 chkccomp.h:
 	echo "#define LIST_DIRECTORY_CONTENTS \"ls\"" > chkccomp.h
-	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto\"" >> chkccomp.h
+	echo "#define CC_OPT_LINK_TIME_OPTIMIZATION \"-flto=auto\"" >> chkccomp.h
 	echo "#define LINKER_OPT_DYN_LINK_LIBS \"-ldl\"" >> chkccomp.h
 	echo "#define X11_LIBRARY_PATH \"/usr/X11R6/lib\"" >> chkccomp.h
 	echo "#define USE_GMP 0" >> chkccomp.h


### PR DESCRIPTION
GCC's `-flto` only uses a single thread by default, which can result in very slow linking and some compiler warnings:

<img width="1248" height="139" alt="flto" src="https://github.com/user-attachments/assets/4a73cd88-a9e4-4b8a-8633-5759536ce8ae" />

Using `-flto=auto` allows the compiler to automatically select the appropriate number of threads, which can speed up the linking process and eliminate warnings.

Clang's `-flto` is equivalent to `-flto=auto` and `-flto=full`, so theoretically clang's compiler options don't need to be changed, but they are also changed to `-flto=auto` in order to keep the code consistent.